### PR TITLE
fix: route writable custom attributes Fusion→SIMPL (command direction)

### DIFF
--- a/src/DynFusionDevice.cs
+++ b/src/DynFusionDevice.cs
@@ -143,6 +143,17 @@ namespace DynFusion
                         new DynFusionDigitalAttribute(att.Name, att.JoinNumber, att.LinkDeviceKey ?? "",
                             att.LinkDeviceMethod ?? "", att.LinkDeviceFeedback ?? ""));
 
+                    // Wire the Fusion -> SIMPL command direction for writable custom attributes.
+                    // Without this, custom attributes were only registered ToFusion, so a Fusion
+                    // write was received/logged but never driven onto the EISC bridge (LinkToApi
+                    // only links trilist.BooleanInput for entries in DigitalAttributesFromFusion).
+                    if ((att.RwType == eReadWrite.Write || att.RwType == eReadWrite.ReadWrite)
+                        && !DigitalAttributesFromFusion.ContainsKey(att.JoinNumber))
+                    {
+                        DigitalAttributesFromFusion.Add(att.JoinNumber,
+                            new DynFusionDigitalAttribute(att.Name, att.JoinNumber));
+                    }
+
                     // Setup input signal linking for readable attributes
                     if (att.RwType != eReadWrite.ReadWrite && att.RwType != eReadWrite.Read)
                     {
@@ -185,6 +196,14 @@ namespace DynFusion
                             AnalogAttributesToFusion.Add(att.JoinNumber,
                                 new DynFusionAnalogAttribute(att.Name, att.JoinNumber, att.LinkDeviceKey ?? "",
                                     att.LinkDeviceMethod ?? "", att.LinkDeviceFeedback ?? ""));
+
+                            // Wire the Fusion -> SIMPL command direction for writable custom attributes.
+                            if ((att.RwType == eReadWrite.Write || att.RwType == eReadWrite.ReadWrite)
+                                && !AnalogAttributesFromFusion.ContainsKey(att.JoinNumber))
+                            {
+                                AnalogAttributesFromFusion.Add(att.JoinNumber,
+                                    new DynFusionAnalogAttribute(att.Name, att.JoinNumber));
+                            }
 
                             // Setup input signal linking for readable attributes
                             if (att.RwType != eReadWrite.ReadWrite && att.RwType != eReadWrite.Read)
@@ -247,6 +266,14 @@ namespace DynFusion
                     SerialAttributesToFusion.Add(att.JoinNumber,
                         new DynFusionSerialAttribute(att.Name, att.JoinNumber, att.LinkDeviceKey ?? "",
                             att.LinkDeviceMethod ?? "", att.LinkDeviceFeedback ?? ""));
+
+                    // Wire the Fusion -> SIMPL command direction for writable custom attributes.
+                    if ((att.RwType == eReadWrite.Write || att.RwType == eReadWrite.ReadWrite)
+                        && !SerialAttributesFromFusion.ContainsKey(att.JoinNumber))
+                    {
+                        SerialAttributesFromFusion.Add(att.JoinNumber,
+                            new DynFusionSerialAttribute(att.Name, att.JoinNumber));
+                    }
 
                     // Setup input signal linking for readable attributes
                     if (att.RwType != eReadWrite.ReadWrite && att.RwType != eReadWrite.Read)


### PR DESCRIPTION
## Problem
Fusion → DynFusion plugin works (writes are received and logged), the EISC bridge is online both sides, but **commands never reach SIMPL** for custom attributes.

## Root cause
`SetupCustomAtributesDigital` / `…Analog` / `…Serial` register every CustomAttribute **only** in the `…AttributesToFusion` (feedback) dictionaries. The Fusion → SIMPL command direction is wired in `LinkToApi` **only** for entries in the `…AttributesFromFusion` dictionaries — and those are populated solely by the fixed standard joins (`CreateStandardJoin`) and by `CustomProperties` (`SetupCustomProperties`), **never by `CustomAttributes`**.

So when Fusion writes a `W`/`RW` custom attribute:
1. `UserConfigured*SigChangeEventId` fires and logs it (`"DynFusion UserAttribute …"`),
2. `…AttributesFromFusion.TryGetValue(joinNumber)` **misses**, so the value is never set and the EISC input join is never driven → nothing reaches SIMPL.

Feedback (`R` attributes), standard Fusion joins (System/Display Power), and `CustomProperties` all work — which masked the gap.

## Fix
In the three `SetupCustomAttributes*` methods, also add attributes whose `RwType` includes **Write** (`Write`/`ReadWrite`) to the corresponding `…AttributesFromFusion` dictionary (guarded with `ContainsKey`). `LinkToApi` already iterates those dicts and links each attribute's feedback to `trilist.<Bool|UShort|String>Input[join]`, and the existing `SigChange` handlers set the value — completing the Fusion → SIMPL path. `RW` attributes correctly populate both dictionaries (EISC input vs output are independent directions on the same join), mirroring how `CreateStandardJoin` already registers standard joins in both.

## Scope / safety
- Read-only (`R`) attributes are unchanged (feedback only).
- `ContainsKey` guard prevents a duplicate-key throw aborting setup if a join is reused by a CustomProperty/standard join.
- No config/join-map changes; no impact to existing feedback or standard joins.

## Verify
- Builds clean: `dotnet build src/epi-crestron-fusion.4series.csproj` → 0 errors (net472).
- Runtime: with `appdebug` verbose, trigger a `W`/`RW` custom attribute from Fusion → the `UserAttribute` log fires **and** the corresponding EISC digital/analog/serial join now drives SIMPL.

## Deploy
Rebuild the `.cplz`, upload to `/user/program1/plugins`, `progreset` the Essentials slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)